### PR TITLE
increase maxscriptsize from 520 to 100000 bytes

### DIFF
--- a/blockchain/fullblocktests/generate.go
+++ b/blockchain/fullblocktests/generate.go
@@ -18,13 +18,10 @@ import (
 	"runtime"
 	"time"
 
-	"sort"
-
-	"github.com/bitcoinsv/bsvd/bsvec"
 	"github.com/bitcoinsv/bsvd/blockchain"
+	"github.com/bitcoinsv/bsvd/bsvec"
 	"github.com/bitcoinsv/bsvd/chaincfg"
 	"github.com/bitcoinsv/bsvd/chaincfg/chainhash"
-	"github.com/bitcoinsv/bsvd/mining"
 	"github.com/bitcoinsv/bsvd/txscript"
 	"github.com/bitcoinsv/bsvd/wire"
 	"github.com/bitcoinsv/bsvutil"
@@ -38,7 +35,7 @@ const (
 	minCoinbaseScriptLen = 2
 	maxCoinbaseScriptLen = 100
 	medianTimeBlocks     = 11
-	maxScriptElementSize = 520
+	maxScriptElementSize = 100000
 
 	// numLargeReorgBlocks is the number of blocks to use in the large block
 	// reorg test (when enabled).  This is the equivalent of 1 week's worth
@@ -1893,7 +1890,7 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 	//
 	//  Comment assumptions:
 	//    maxBlockSigOps = 20000
-	//    maxScriptElementSize = 520
+	//    maxScriptElementSize = 100000
 	//
 	//  [0-19999]    : OP_CHECKSIG
 	//  [20000]      : OP_PUSHDATA4

--- a/txscript/engine.go
+++ b/txscript/engine.go
@@ -92,7 +92,7 @@ const (
 	MaxStackSize = 1000
 
 	// MaxScriptSize is the maximum allowed length of a raw script.
-	MaxScriptSize = 10000
+	MaxScriptSize = 110000
 )
 
 // halforder is used to tame ECDSA malleability (see BIP0062).

--- a/txscript/script.go
+++ b/txscript/script.go
@@ -41,9 +41,9 @@ const (
 
 // These are the constants specified for maximums in individual scripts.
 const (
-	MaxOpsPerScript       = 201 // Max number of non-push operations.
-	MaxPubKeysPerMultiSig = 20  // Multisig can't have more sigs than this.
-	MaxScriptElementSize  = 520 // Max bytes pushable to the stack.
+	MaxOpsPerScript       = 201    // Max number of non-push operations.
+	MaxPubKeysPerMultiSig = 20     // Multisig can't have more sigs than this.
+	MaxScriptElementSize  = 100000 // Max bytes pushable to the stack.
 )
 
 // isSmallInt returns whether or not the opcode is considered a small integer,

--- a/txscript/scriptbuilder_test.go
+++ b/txscript/scriptbuilder_test.go
@@ -213,7 +213,7 @@ func TestScriptBuilderAddData(t *testing.T) {
 			expected: append([]byte{OP_PUSHDATA1, 255}, bytes.Repeat([]byte{0x49}, 255)...),
 		},
 
-		// BIP0062: Pushing 256 to 520 bytes must use OP_PUSHDATA2.
+		// Pushing 256 to 65535 bytes must use OP_PUSHDATA2.
 		{
 			name:     "push data len 256",
 			data:     bytes.Repeat([]byte{0x49}, 256),
@@ -225,22 +225,34 @@ func TestScriptBuilderAddData(t *testing.T) {
 			expected: append([]byte{OP_PUSHDATA2, 0x08, 0x02}, bytes.Repeat([]byte{0x49}, 520)...),
 		},
 
-		// BIP0062: OP_PUSHDATA4 can never be used, as pushes over 520
-		// bytes are not allowed, and those below can be done using
-		// other operators.
+		// OP_PUSHDATA4
+		// 520 was the previous limit under BIP0062. Test 521 bytes and beyond
 		{
 			name:     "push data len 521",
 			data:     bytes.Repeat([]byte{0x49}, 521),
-			expected: nil,
+			expected: append([]byte{OP_PUSHDATA2, 0x09, 0x02}, bytes.Repeat([]byte{0x49}, 521)...),
 		},
 		{
 			name:     "push data len 32767 (canonical)",
 			data:     bytes.Repeat([]byte{0x49}, 32767),
-			expected: nil,
+			expected: append([]byte{OP_PUSHDATA2, 0xFF, 0x7F}, bytes.Repeat([]byte{0x49}, 32767)...),
 		},
+		// Pushing 65536 to 100000 must use OP_PUSHDATA4
 		{
 			name:     "push data len 65536 (canonical)",
 			data:     bytes.Repeat([]byte{0x49}, 65536),
+			expected: append([]byte{OP_PUSHDATA4, 0x00, 0x00, 0x01, 0x00}, bytes.Repeat([]byte{0x49}, 65536)...),
+		},
+		// Pushing maximum bytes allowed
+		{
+			name:     "push data len 100000 (canonical)",
+			data:     bytes.Repeat([]byte{0x49}, 100000),
+			expected: append([]byte{OP_PUSHDATA4, 0xA0, 0x86, 0x01, 0x00}, bytes.Repeat([]byte{0x49}, 100000)...),
+		},
+		// Pushing more than 100000 should fail
+		{
+			name:     "push data 4 len 100001 (non-canonical)",
+			data:     bytes.Repeat([]byte{0x49}, 100001),
 			expected: nil,
 		},
 
@@ -248,19 +260,11 @@ func TestScriptBuilderAddData(t *testing.T) {
 		// intentionally allows data pushes to exceed the limit for
 		// regression testing purposes.
 
-		// 3-byte data push via OP_PUSHDATA_2.
-		{
-			name:     "push data len 32767 (non-canonical)",
-			data:     bytes.Repeat([]byte{0x49}, 32767),
-			expected: append([]byte{OP_PUSHDATA2, 255, 127}, bytes.Repeat([]byte{0x49}, 32767)...),
-			useFull:  true,
-		},
-
 		// 5-byte data push via OP_PUSHDATA_4.
 		{
-			name:     "push data len 65536 (non-canonical)",
-			data:     bytes.Repeat([]byte{0x49}, 65536),
-			expected: append([]byte{OP_PUSHDATA4, 0, 0, 1, 0}, bytes.Repeat([]byte{0x49}, 65536)...),
+			name:     "push data 4 len 100001 (non-canonical)",
+			data:     bytes.Repeat([]byte{0x49}, 100001),
+			expected: append([]byte{OP_PUSHDATA4, 0xA1, 0x86, 0x01, 0x00}, bytes.Repeat([]byte{0x49}, 100001)...),
 			useFull:  true,
 		},
 	}

--- a/txscript/scriptbuilder_test.go
+++ b/txscript/scriptbuilder_test.go
@@ -251,7 +251,7 @@ func TestScriptBuilderAddData(t *testing.T) {
 		},
 		// Pushing more than 100000 should fail
 		{
-			name:     "push data 4 len 100001 (non-canonical)",
+			name:     "push data len 100001 (non-canonical)",
 			data:     bytes.Repeat([]byte{0x49}, 100001),
 			expected: nil,
 		},
@@ -262,7 +262,7 @@ func TestScriptBuilderAddData(t *testing.T) {
 
 		// 5-byte data push via OP_PUSHDATA_4.
 		{
-			name:     "push data 4 len 100001 (non-canonical)",
+			name:     "push data len 100001 (non-canonical)",
 			data:     bytes.Repeat([]byte{0x49}, 100001),
 			expected: append([]byte{OP_PUSHDATA4, 0xA1, 0x86, 0x01, 0x00}, bytes.Repeat([]byte{0x49}, 100001)...),
 			useFull:  true,


### PR DESCRIPTION
refs #1 

There are a few things to consider with this:

- txscript tests might need to be restructured a bit. They iterate a lot now, and take several orders of magnitude longer to complete.
- There are test parameters in txscript/data/script_tests.json that would require very large string payloads to make them pass (one 'b' character per byte). Not sure how these should be handled.
- The wire package also has a limit in const MaxFilterAddDataSize of 520 bytes in wire/msgfilteradd.go According to this:
https://github.com/bitcoin/bips/blob/master/bip-0037.mediawiki
the maximum payload size is 36,000 bytes, which is exceeded by this new limit.
- Also some of the tests in wire seem to assume 3 bytes max for OP_PUSHDATA_2 instead of 5 for OP_PUSHDATA_4